### PR TITLE
Don't default to returning the current document if the specified rev …

### DIFF
--- a/get_test.go
+++ b/get_test.go
@@ -184,6 +184,14 @@ func TestGet(t *testing.T) {
 			Rev:           "2-xxx",
 		},
 	})
+	tests.Add("specify bogus rev yaml", tt{
+		path:    "testdata",
+		dbname:  "db.foo",
+		id:      "yamltest",
+		options: map[string]interface{}{"rev": "1-oink"},
+		status:  http.StatusNotFound,
+		err:     "missing",
+	})
 	tests.Add("ddoc yaml", tt{
 		path:   "testdata",
 		dbname: "db.foo",

--- a/normalize.go
+++ b/normalize.go
@@ -359,6 +359,7 @@ func (d *db) openDoc(docID, rev string) (*os.File, string, error) {
 				if !os.IsNotExist(err) {
 					return f, ext, err
 				}
+				continue
 			}
 		}
 		f, err := os.Open(d.path(filename))


### PR DESCRIPTION
…doesn't exist