### PR TITLE
Add support for file:// URLs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Package fsdb provides a filesystem-backed Kivik driver. This driver is very
+Package fs provides a filesystem-backed Kivik driver. This driver is very
 much a work in progress. Please refer to the GitHub page for current status and
 ongoing changes. https://github.com/go-kivik/fsdb
 
@@ -25,6 +25,19 @@ For example:
 
     db := client.DB(ctx, "foo")
 
-would look for document files in `/home/usr/some/path/foo`
+would look for document files in `/home/usr/some/path/foo`.
+
+Connection Strings
+
+This driver supports three types of connection strings to the New() method:
+
+ - Local filesystem path. This may be relative or absolute. Examples:
+   `/home/user/some/path` and './some/path'
+ - A full file:// URL. Example: 'file:///home/user/some/path'
+ - An empty string (""), which requires the full path to the database is passed
+   to the `DB()` method. In this case, the argument to `DB()` accepts the first
+   two formats, with the final path element being the database name. Some
+   client-level methods, such as AllDBs(), are unavailable, when using an empty
+   connection string.
 */
 package fs

--- a/fs.go
+++ b/fs.go
@@ -115,15 +115,12 @@ func (c *client) CreateDB(ctx context.Context, dbName string, options map[string
 	if exists {
 		return &kivik.Error{HTTPStatus: http.StatusPreconditionFailed, Message: "database already exists"}
 	}
-	if err := os.Mkdir(c.root+"/"+cdb.EscapeID(dbName), dirMode); err != nil {
-		return err
-	}
-	return nil
+	return os.Mkdir(filepath.Join(c.root, cdb.EscapeID(dbName)), dirMode)
 }
 
 // DBExistsreturns true if the database exists.
 func (c *client) DBExists(_ context.Context, dbName string, _ map[string]interface{}) (bool, error) {
-	_, err := os.Stat(c.root + "/" + cdb.EscapeID(dbName))
+	_, err := os.Stat(filepath.Join(c.root, cdb.EscapeID(dbName)))
 	if err == nil {
 		return true, nil
 	}
@@ -142,7 +139,8 @@ func (c *client) DestroyDB(ctx context.Context, dbName string, options map[strin
 	if !exists {
 		return &kivik.Error{HTTPStatus: http.StatusNotFound, Message: "database does not exist"}
 	}
-	return os.RemoveAll(c.root + "/" + cdb.EscapeID(dbName))
+	// FIXME #65: Be safer here about unrecognized files
+	return os.RemoveAll(filepath.Join(c.root, cdb.EscapeID(dbName)))
 }
 
 func (c *client) DB(_ context.Context, dbName string, _ map[string]interface{}) (driver.DB, error) {

--- a/fs.go
+++ b/fs.go
@@ -155,6 +155,7 @@ func (c *client) DB(_ context.Context, dbName string, _ map[string]interface{}) 
 // dbPath returns the full DB path, or an error if the dbpath conflicts with
 // the client root path.
 func (c *client) dbPath(path string) (string, error) {
+	dbname := path
 	if c.root == "" {
 		if strings.HasPrefix(path, "file://") {
 			addr, err := url.Parse(path)
@@ -163,19 +164,16 @@ func (c *client) dbPath(path string) (string, error) {
 			}
 			path = addr.Path
 		}
-		dbname := path
 		if strings.Contains(dbname, "/") {
 			dbname = dbname[strings.LastIndex(dbname, "/")+1:]
 		}
-		if !validDBNameRE.MatchString(dbname) {
-			return "", illegalDBName(dbname)
-		}
-		return path, nil
+	} else {
+		path = filepath.Join(c.root, dbname)
 	}
-	if !validDBNameRE.MatchString(path) {
-		return "", illegalDBName(path)
+	if !validDBNameRE.MatchString(dbname) {
+		return "", illegalDBName(dbname)
 	}
-	return filepath.Join(c.root, path), nil
+	return path, nil
 }
 
 func (c *client) newDB(dbname string) (*db, error) {

--- a/fs.go
+++ b/fs.go
@@ -97,7 +97,12 @@ func (c *client) AllDBs(ctx context.Context, _ map[string]interface{}) ([]string
 	}
 	filenames := make([]string, 0, len(files))
 	for _, file := range files {
-		if !validDBNameRE.MatchString(file.Name()) {
+		dbname, err := cdb.UnescapeID(file.Name())
+		if err != nil {
+			// FIXME #64: Add option to warn about non-matching files?
+			continue
+		}
+		if !validDBNameRE.MatchString(dbname) {
 			// FIXME #64: Add option to warn about non-matching files?
 			continue
 		}

--- a/fs.go
+++ b/fs.go
@@ -87,7 +87,10 @@ func (c *client) Version(_ context.Context) (*driver.Version, error) {
 var validDBNameRE = regexp.MustCompile("^[a-z_][a-z0-9_$()+/-]*$")
 
 // AllDBs returns a list of all DBs present in the configured root dir.
-func (c *client) AllDBs(_ context.Context, _ map[string]interface{}) ([]string, error) {
+func (c *client) AllDBs(ctx context.Context, _ map[string]interface{}) ([]string, error) {
+	if c.root == "" {
+		return nil, &kivik.Error{HTTPStatus: http.StatusBadRequest, Message: "no root path provided"}
+	}
 	files, err := ioutil.ReadDir(c.root)
 	if err != nil {
 		return nil, err

--- a/fs_test.go
+++ b/fs_test.go
@@ -87,6 +87,12 @@ func TestClientdbPath(t *testing.T) {
 		dbname: "file:///foo/bar",
 		path:   "/foo/bar",
 	})
+	tests.Add("file:// url for db with invalid db name", tt{
+		root:   "",
+		dbname: "file:///foo/bar.baz",
+		status: http.StatusBadRequest,
+		err:    `Name: 'bar.baz'. Only lowercase characters (a-z), digits (0-9), and any of the characters _, $, (, ), +, -, and / are allowed. Must begin with a letter.`,
+	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
 		c := &client{root: tt.root}

--- a/fs_test.go
+++ b/fs_test.go
@@ -34,6 +34,11 @@ func TestAllDBs(t *testing.T) {
 			"get_split_atts",
 		},
 	})
+	tests.Add("No root path", tt{
+		path:   "",
+		status: http.StatusBadRequest,
+		err:    "no root path provided",
+	})
 
 	d := &fsDriver{}
 	tests.Run(t, func(t *testing.T, tt tt) {


### PR DESCRIPTION
This finalizes support for `file://` connection strings, either to the `NewClient` method, or to the `DB()` method. The latter makes it possible to deal directly with directories such as `.` when using this driver, without having to specify the parent directory.